### PR TITLE
used should count terminating

### DIFF
--- a/api_general_autoscale.go
+++ b/api_general_autoscale.go
@@ -61,8 +61,10 @@ func (as *autoscaler) autoScale(out []*NodeInfo, pendC int, pendD int) {
 	for _, e := range out {
 		if !e.Status.Disabled && !e.Status.Terminate {
 			globtotal = globtotal + e.RamTotal
-			globused = globused + e.RamUsed
 			numActive++
+		}
+		if e.Status.Terminate || !e.Status.Disabled {
+			globused = globused + e.RamUsed
 		}
 	}
 


### PR DESCRIPTION
used should include terminating nodes, because their ram will migrate
otherwise we get in a stupid situation where it keeps terminating, and that used disappears, so it terminates again, and then it has to create because all that stuff gets migrated back

the condition wants to catch nodes that are terminating, or non-terminating and non-disabled. If they are non-terminating and disabled, then we should not count the used. (effectively nodes that are only disabled don't exist). We disable nodes that are terminating, making the condition more complicated than just always adding it
